### PR TITLE
Add GHA Scanner to IaC Security section

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ Scan infrastructure configurations for security misconfigurations.
 - [snyk-iac](https://github.com/snyk/cli) - Infrastructure as Code security scanning. ![Active](https://img.shields.io/badge/status-active-brightgreen) ![Stars](https://img.shields.io/github/stars/snyk/cli) ![Last Commit](https://img.shields.io/github/last-commit/snyk/cli)
 - [cfn-lint](https://github.com/aws-cloudformation/cfn-lint) - AWS CloudFormation linter with security rules. ![Active](https://img.shields.io/badge/status-active-brightgreen) ![Stars](https://img.shields.io/github/stars/aws-cloudformation/cfn-lint) ![Last Commit](https://img.shields.io/github/last-commit/aws-cloudformation/cfn-lint)
 - [zizmor](https://github.com/zizmorcore/zizmor) - Static analysis for GitHub Actions workflows. ![Active](https://img.shields.io/badge/status-active-brightgreen) ![Stars](https://img.shields.io/github/stars/zizmorcore/zizmor) ![Last Commit](https://img.shields.io/github/last-commit/zizmorcore/zizmor)
+- [gha-scanner](https://github.com/raajheshkannaa/gha-scanner) - Security scanner for GitHub Actions workflows with 25 checks across 8 categories. Web UI, CLI, and GitHub Action. ![Active](https://img.shields.io/badge/status-active-brightgreen) ![Stars](https://img.shields.io/github/stars/raajheshkannaa/gha-scanner) ![Last Commit](https://img.shields.io/github/last-commit/raajheshkannaa/gha-scanner)
 
 ## Container Security
 


### PR DESCRIPTION
## Add GHA Scanner

[GHA Scanner](https://github.com/raajheshkannaa/gha-scanner) is a free, open-source security scanner for GitHub Actions workflows.

- 25 security checks across 8 categories (injection risks, permissions, secrets exposure, pinning, OIDC, caching, runner security, and more)
- Available as a [web UI](https://scan.defensive.works), CLI, and [GitHub Action on the marketplace](https://github.com/marketplace/actions/gha-scanner)
- MIT licensed

It fits alongside zizmor in the Infrastructure as Code Security section as another tool for scanning GitHub Actions workflow files for security issues.

I use and maintain this tool.